### PR TITLE
add check for number of token pair auctions on DutchExchange

### DIFF
--- a/src/abis/dutchExchangeABI.js
+++ b/src/abis/dutchExchangeABI.js
@@ -1,0 +1,56 @@
+module.exports = [
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "name": "token2",
+        "type": "address"
+      },
+      {
+        "name": "auctionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPriceInPastAuction",
+    "outputs": [
+      {
+        "name": "num",
+        "type": "uint256"
+      },
+      {
+        "name": "den",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "name": "token2",
+        "type": "address"
+      }
+    ],
+    "name": "getAuctionIndex",
+    "outputs": [
+      {
+        "name": "auctionIndex",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abis/futarchyChallengeFactoryABI.js
+++ b/src/abis/futarchyChallengeFactoryABI.js
@@ -1,0 +1,212 @@
+module.exports = [
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "timeToPriceResolution",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "NUM_PRICE_POINTS",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "scalarPriceOracleFactory",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "stakeAmount",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "dutchExchange",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "futarchyOracleFactory",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lmsrMarketMaker",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comparatorToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "tradingPeriod",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "_comparatorToken",
+        "type": "address"
+      },
+      {
+        "name": "_stakeAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "_tradingPeriod",
+        "type": "uint256"
+      },
+      {
+        "name": "_timeToPriceResolution",
+        "type": "uint256"
+      },
+      {
+        "name": "_futarchyOracleFactory",
+        "type": "address"
+      },
+      {
+        "name": "_scalarPriceOracleFactory",
+        "type": "address"
+      },
+      {
+        "name": "_lmsrMarketMaker",
+        "type": "address"
+      },
+      {
+        "name": "_dutchExchange",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "upperBound",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "lowerBound",
+        "type": "int256"
+      }
+    ],
+    "name": "SetUpperAndLowerBound",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_registry",
+        "type": "address"
+      },
+      {
+        "name": "_challenger",
+        "type": "address"
+      },
+      {
+        "name": "_listingOwner",
+        "type": "address"
+      }
+    ],
+    "name": "createChallenge",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,34 @@
 const token = require('./token')
 const registry = require('./registry')
-const LMSRMarketMakerABI = require('./abis/LMSRMarketMakerABI')
+const futarchyChallengeFactoryABI = require('./abis/futarchyChallengeFactoryABI')
 const decisions = require('./enums/decisions')
 const outcomes = require('./enums/outcomes')
 const outcomeTokens = require('./enums/outcomeTokens')
 
 module.exports = (web3, config) => {
+
+  if (!config.tokenAddress) {
+    throw new Error(`tokenAddress was not provided in config`)
+  }
+  if (!config.registryAddress) {
+    throw new Error(`registryAddress was not provided in config`)
+  }
+  if (!config.futarchyChallengeFactoryAddress) {
+    throw new Error(`futarchyChallengeFactoryAddress was not provided in config`)
+  }
+
   const tokenInstance = token(web3, config.tokenAddress, config.defaultOptions)
-  const LMSRMarketMaker = new web3.eth.Contract(
-    LMSRMarketMakerABI,
-    config.LMSRMarketMakerAddress
+
+  const futarchyChallengeFactory = new web3.eth.Contract(
+    futarchyChallengeFactoryABI,
+    config.futarchyChallengeFactoryAddress
   )
+
   return {
     token: tokenInstance,
-    LMSRMarketMaker,
     registry: registry(
       tokenInstance,
-      LMSRMarketMaker,
+      futarchyChallengeFactory,
       web3,
       config.registryAddress,
       config.defaultOptions


### PR DESCRIPTION
if there is not enough historical data (currentAuctionIndex does not exceed NUM_PRICE_POINTS) then the FutarchyChallengeFactory.createChallenge will revert when it tries to determine the upper/lower bounds for the scalar markets. This adds a check for this condition and throws an error.

Since this required us to access an instance of FutarchyChallengeFactory, which stores the LMSRMarketMaker address, the LMSRMarketMaker config was removed and replaced with a call to FutarchyChallengeFactory.