### PR TITLE
add `events()` functions to log all past events for every contract

### DIFF
--- a/src/allEventsPromises.js
+++ b/src/allEventsPromises.js
@@ -1,0 +1,33 @@
+module.exports = function (contracts) {
+  let i = 0
+  let eventsPromises = []
+  let contractNames = []
+  for(const contractName in contracts) {
+    eventsPromises[i] = pastEventsPromise(contracts[contractName])
+    contractNames[i] = contractName
+    i++
+  }
+  return new Promise((resolve, reject) => {
+    Promise.all(eventsPromises).then((eventResults) => {
+      let formattedResults = {}
+      for(let j in contractNames) {
+        formattedResults[contractNames[j]] = eventResults[j]
+      }
+      resolve(formattedResults)
+    }, reject)
+    .catch(reject)
+  })
+}
+
+function pastEventsPromise (contractInstance) {
+  return new Promise(((resolve, reject) => {
+    contractInstance.getPastEvents(
+      'allEvents',
+      { fromBlock: 0, toBlock: 'latest' },
+      (err, events) => {
+        if (err) reject(err)
+        else resolve(events)
+      }
+    )
+  }))
+}

--- a/src/challenge.js
+++ b/src/challenge.js
@@ -10,6 +10,7 @@ const decisions = require('./enums/decisions')
 const outcomes = require('./enums/outcomes')
 const challengeStatuses = require('./enums/challengeStatuses')
 const token = require('./token')
+const allEventsPromises = require('./allEventsPromises')
 
 function decisionForOutcome (outcome) {
   return outcome.indexOf('ACCEPTED') > -1 ? 'ACCEPTED' : 'DENIED'
@@ -557,6 +558,36 @@ module.exports = (fcrToken, LMSR, web3, id, address, defaultOptions) => {
     )
   }
 
+  const events = async () => {
+    const futarchyOracle = await getFutarchyOracle()
+    const categoricalEvent = await getCategoricalEvent()
+    const decisionMarket_ACCEPTED = await getDecisionMarket('ACCEPTED')
+    const decisionMarket_DENIED = await getDecisionMarket('DENIED')
+    const decisionEvent_ACCEPTED = await getDecisionEvent('ACCEPTED')
+    const decisionEvent_DENIED = await getDecisionEvent('DENIED')
+    const decisionToken_ACCEPTED = await getDecisionToken('ACCEPTED')
+    const decisionToken_DENIED = await getDecisionToken('DENIED')
+    const outcomeToken_LONG_ACCEPTED = await getOutcomeToken('LONG_ACCEPTED')
+    const outcomeToken_SHORT_ACCEPTED = await getOutcomeToken('SHORT_ACCEPTED')
+    const outcomeToken_LONG_DENIED = await getOutcomeToken('LONG_DENIED')
+    const outcomeToken_SHORT_DENIED = await getOutcomeToken('SHORT_DENIED')
+    return allEventsPromises({
+      Challenge: contract,
+      FutarchyOracle: futarchyOracle,
+      CategoricalEvent: categoricalEvent,
+      StandardMarketWithPriceLogger_ACCEPTED: decisionMarket_ACCEPTED,
+      StandardMarketWithPriceLogger_DENIED: decisionMarket_DENIED,
+      ScalarEvent_ACCEPTED: decisionEvent_ACCEPTED,
+      ScalarEvent_DENIED: decisionEvent_DENIED,
+      CollateralToken_ACCEPTED: decisionToken_ACCEPTED.contract,
+      CollateralToken_DENIED: decisionToken_DENIED.contract,
+      OutcomeToken_LONG_ACCEPTED: outcomeToken_LONG_ACCEPTED.contract,
+      OutcomeToken_SHORT_ACCEPTED: outcomeToken_SHORT_ACCEPTED.contract,
+      OutcomeToken_LONG_DENIED: outcomeToken_LONG_DENIED.contract,
+      OutcomeToken_SHORT_DENIED: outcomeToken_SHORT_DENIED.contract
+    })
+  }
+
   return {
     ID: id,
     start,
@@ -594,6 +625,7 @@ module.exports = (fcrToken, LMSR, web3, id, address, defaultOptions) => {
     watchFunded: watchEventFn(contract, '_Funded'),
     watchOutcomeTokenTrades,
     watchSetOutcome,
+    events,
     address,
     contract,
     close

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const futarchyChallengeFactoryABI = require('./abis/futarchyChallengeFactoryABI'
 const decisions = require('./enums/decisions')
 const outcomes = require('./enums/outcomes')
 const outcomeTokens = require('./enums/outcomeTokens')
+const allEventsPromises = require('./allEventsPromises')
 
 module.exports = (web3, config) => {
 
@@ -24,15 +25,30 @@ module.exports = (web3, config) => {
     config.futarchyChallengeFactoryAddress
   )
 
+  const registryInstance = registry(
+    tokenInstance,
+    futarchyChallengeFactory,
+    web3,
+    config.registryAddress,
+    config.defaultOptions
+  )
+
+  const events = async () => {
+    const dutchExchange = await registryInstance.getDutchExchange()
+    const lmsr = await registryInstance.getLMSR()
+    return allEventsPromises({
+      Token: tokenInstance.contract,
+      Registry: registryInstance.contract,
+      FutarchyChallengeFactory: futarchyChallengeFactory,
+      DutchExchange: dutchExchange,
+      LMSR: lmsr
+    })
+  }
+
   return {
+    events,
     token: tokenInstance,
-    registry: registry(
-      tokenInstance,
-      futarchyChallengeFactory,
-      web3,
-      config.registryAddress,
-      config.defaultOptions
-    ),
+    registry: registryInstance,
     decisions,
     outcomes,
     outcomeTokens

--- a/src/registry.js
+++ b/src/registry.js
@@ -126,10 +126,14 @@ module.exports = (token, futarchyChallengeFactory, web3, address, defaultOptions
   const getChallenge = async (challengeNonce) => {
     const challengeResp = await contract.methods.challenges(challengeNonce).call()
     const { challengeAddress } = challengeResp
+    const LMSR = await getLMSR()
+    return challenge(token, LMSR, web3, challengeNonce, challengeAddress, defaultOptions)
+  }
+
+  const getLMSR = async () => {
     const lmsrMarketMakerAddress = 
       await futarchyChallengeFactory.methods.lmsrMarketMaker().call()
-    const LMSR = new web3.eth.Contract(LMSRMarketMakerABI, lmsrMarketMakerAddress)
-    return challenge(token, LMSR, web3, challengeNonce, challengeAddress, defaultOptions)
+    return new web3.eth.Contract(LMSRMarketMakerABI, lmsrMarketMakerAddress)
   }
 
   const getAllChallenges = async () => {
@@ -184,6 +188,8 @@ module.exports = (token, futarchyChallengeFactory, web3, address, defaultOptions
     getAllChallenges,
     getListing,
     getChallenge,
+    getDutchExchange,
+    getLMSR,
     name,
     contract,
     address,


### PR DESCRIPTION
mostly for debugging .. let's us get all the events that have been emitted for every contract in FCR in one function call. Can be used at top level `fcr.events()` or at the challenge level `fcr.getChallenge(123).events()`